### PR TITLE
Fix python_version format

### DIFF
--- a/cofenseintelligence.json
+++ b/cofenseintelligence.json
@@ -16,10 +16,7 @@
     "fips_compliant": true,
     "logo": "logo_cofenseintelligence.svg",
     "logo_dark": "logo_cofenseintelligence_dark.svg",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "latest_tested_versions": [
         "Cloud API v1 tested on 30/03/2021"
     ],

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)